### PR TITLE
Switch from React.PropTypes to the separate 'prop-types' library

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,32 +36,34 @@
   },
   "homepage": "https://github.com/leonaves/react-touch",
   "peerDependencies": {
-    "react": "^0.14 || ^15.0"
+    "react": "^0.14.9 || ^15.3.0"
   },
   "dependencies": {
     "lodash": "4.6.1",
+    "prop-types": "^15.5.7",
     "raf": "3.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.6.4",
     "babel-eslint": "6.0.0",
     "babel-loader": "6.2.4",
+    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-plugin-transform-class-properties": "6.6.0",
     "babel-plugin-transform-react-jsx": "6.4.0",
-    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-stage-2": "6.5.0",
-    "codecov.io": "0.1.6",
     "chai": "3.5.0",
+    "codecov.io": "0.1.6",
     "eslint": "2.4.0",
     "eslint-config-airbnb": "6.1.0",
     "eslint-plugin-react": "4.2.3",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "8.1.0",
     "mocha": "2.4.5",
+    "prop-types": "^15.5.10",
     "react": "^0.14",
-    "react-dom": "^0.14",
     "react-addons-test-utils": "^0.14",
+    "react-dom": "^0.14",
     "sinon": "1.17.3",
     "webpack": "1.12.14"
   }

--- a/src/CustomGesture.react.js
+++ b/src/CustomGesture.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import isArray from 'lodash/isArray';
 import merge from 'lodash/merge';
@@ -9,7 +10,6 @@ import gestureLevenshtein from './gestureLevenshtein';
 import convertToDefaultsObject from './convertToDefaultsObject';
 import { createSectors, computeSectorIdx } from './circleMath';
 
-const T = React.PropTypes;
 
 const INITIAL_STATE = { current: null, moves: [] };
 const DEFAULT_CONFIG = { fudgeFactor: 5, minMoves: 8, gesture: "" };

--- a/src/Draggable.react.js
+++ b/src/Draggable.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 
 import TouchHandler from './TouchHandler';
@@ -6,7 +7,6 @@ import computePositionStyle from './computePositionStyle';
 import computeDeltas from './computeDeltas';
 
 
-const T = React.PropTypes;
 const ZERO_DELTAS = { dx: 0, dy: 0 };
 const DEFAULT_TOUCH = { initial: null, current: null, deltas: ZERO_DELTAS };
 

--- a/src/Holdable.react.js
+++ b/src/Holdable.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 import clamp from 'lodash/clamp';
@@ -7,7 +8,6 @@ import defineHold from './defineHold';
 import TouchHandler from './TouchHandler';
 
 
-const T = React.PropTypes;
 const DEFAULT_HOLD = { initial: null, current: null, duration: 0 };
 
 class Holdable extends React.Component {

--- a/src/Swipeable.react.js
+++ b/src/Swipeable.react.js
@@ -1,12 +1,11 @@
 import React from 'react';
+import { PropTypes as T } from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 
 import TouchHandler from './TouchHandler';
 import defineSwipe from './defineSwipe';
 
-
-const T = React.PropTypes;
 const DIRECTIONS = ['Left', 'Right', 'Up', 'Down'];
 const ZERO_DELTAS = { dx: 0, dy: 0 };
 const DEFAULT_STATE = { initial: null, current: null, deltas: ZERO_DELTAS };


### PR DESCRIPTION
This prevents deprecation warnings when using `react-touch` with newer versions of React.

It adds the `prop-types` package to `react-touch`'s dependencies, which is [Facebook's recommended approach](https://github.com/facebook/prop-types#how-to-depend-on-this-package).

However, `prop-types` only works with React versions 0.14.9 or 15.3 an above, so I've also bumped the minimum version numbers in `peerDependencies`.

Fixes #6 