### PR TITLE
Use cross-env to allow for building on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "watch:examples": "npm run build:examples -- --watch",
     "lint": "eslint src",
     "prepublish": "rm -rf lib && npm test && npm run build",
-    "test": "NODE_ENV=test mocha --compilers js:babel-register src/**/tests/*",
+    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register src/**/tests/*",
     "test:one": "npm test -- -g",
     "test:watch": "npm test -- --watch",
-    "test:cov": "NODE_ENV=test babel-node ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- 'src/**/tests/*'",
+    "test:cov": "cross-env NODE_ENV=test babel-node ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- 'src/**/tests/*'",
     "test:codecov": "cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"
   },
   "keywords": [
@@ -54,6 +54,7 @@
     "babel-preset-stage-2": "6.5.0",
     "chai": "3.5.0",
     "codecov.io": "0.1.6",
+    "cross-env": "^5.1.1",
     "eslint": "2.4.0",
     "eslint-config-airbnb": "6.1.0",
     "eslint-plugin-react": "4.2.3",


### PR DESCRIPTION
I ended up cloning `react-touch` to see how it works while developing my application and noticed it doesn't build on Windows due to Windows not liking environmental variables being set in the scripts.

So I added `cross-env` so that building works Windows.